### PR TITLE
Added implementation as source filters

### DIFF
--- a/src/engine_filters/mod.rs
+++ b/src/engine_filters/mod.rs
@@ -1,0 +1,5 @@
+mod pauseable;
+pub use self::pauseable::Pauseable;
+
+mod volume_filter;
+pub use self::volume_filter::VolumeFilter;

--- a/src/engine_filters/pauseable.rs
+++ b/src/engine_filters/pauseable.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use Sample;
+use Source;
+
+/// Filter that allows another thread to pause the stream.
+#[derive(Clone, Debug)]
+pub struct Pauseable<I> where I: Source, I::Item: Sample {
+    input: I,
+
+    //Local storage of the paused value.  Allows us to only check the remote occasionally.
+    local_paused: bool,
+
+    //The paused value which may be manipulated by another thread.
+    remote_paused: Arc<AtomicBool>,
+
+    //The frequency with which local_paused should be updated by remote_paused
+    update_frequency: u32,
+
+    //How many samples remain until it is time to update local_paused with remote_paused.
+    samples_until_update: u32,
+}
+
+impl<I> Pauseable<I> where I: Source, I::Item: Sample {
+    pub fn new(source: I, remote_paused: Arc<AtomicBool>, update_ms: u32) -> Pauseable<I> {
+        let update_frequency = (update_ms * source.get_samples_rate())/1000;
+        Pauseable {
+            input: source,
+            local_paused: remote_paused.load(Ordering::Relaxed),
+            remote_paused: remote_paused,
+            update_frequency: update_frequency,
+            samples_until_update: update_frequency,
+        }
+    }
+}
+
+impl<I> Iterator for Pauseable<I> where I: Source, I::Item: Sample {
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        self.samples_until_update -= 1;
+        if self.samples_until_update == 0 {
+            self.local_paused = self.remote_paused.load(Ordering::Relaxed);
+            self.samples_until_update = self.update_frequency;
+        }
+        if self.local_paused {
+            return Some(I::Item::zero_value());
+        }
+        self.input.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+impl<I> Source for Pauseable<I> where I: Source, I::Item: Sample {
+    #[inline]
+    fn get_current_frame_len(&self) -> Option<usize> {
+        self.input.get_current_frame_len()
+    }
+
+    #[inline]
+    fn get_channels(&self) -> u16 {
+        self.input.get_channels()
+    }
+
+    #[inline]
+    fn get_samples_rate(&self) -> u32 {
+        self.input.get_samples_rate()
+    }
+
+    #[inline]
+    fn get_total_duration(&self) -> Option<Duration> {
+        self.input.get_total_duration()
+    }
+}

--- a/src/engine_filters/pauseable.rs
+++ b/src/engine_filters/pauseable.rs
@@ -25,7 +25,7 @@ pub struct Pauseable<I> where I: Source, I::Item: Sample {
 
 impl<I> Pauseable<I> where I: Source, I::Item: Sample {
     pub fn new(source: I, remote_paused: Arc<AtomicBool>, update_ms: u32) -> Pauseable<I> {
-        let update_frequency = (update_ms * source.get_samples_rate())/1000;
+        let update_frequency = (update_ms * source.get_samples_rate())/1000; // TODO: handle the fact that the samples rate can change
         Pauseable {
             input: source,
             local_paused: remote_paused.load(Ordering::Relaxed),

--- a/src/engine_filters/volume_filter.rs
+++ b/src/engine_filters/volume_filter.rs
@@ -25,7 +25,7 @@ pub struct VolumeFilter<I> where I: Source, I::Item: Sample {
 
 impl<I> VolumeFilter<I> where I: Source, I::Item: Sample {
     pub fn new(source: I, remote_volume: Arc<Mutex<f32>>, update_ms: u32) -> VolumeFilter<I> {
-        let update_frequency = (update_ms * source.get_samples_rate())/1000;
+        let update_frequency = (update_ms * source.get_samples_rate())/1000; // TODO: handle the fact that the samples rate can change
         VolumeFilter {
             input: source,
             local_volume: *remote_volume.lock().unwrap(),

--- a/src/engine_filters/volume_filter.rs
+++ b/src/engine_filters/volume_filter.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+use std::time::Duration;
+use std::sync::Mutex;
+
+use Sample;
+use Source;
+
+/// Filter that allows another thread to set the volume concurrently.
+#[derive(Clone, Debug)]
+pub struct VolumeFilter<I> where I: Source, I::Item: Sample {
+    input: I,
+
+    //Local storage of the volume value.  Allows us to only check the remote occasionally.
+    local_volume: f32,
+
+    //The volume value which may be manipulated by another thread.
+    remote_volume: Arc<Mutex<f32>>,
+
+    //The frequency with which local_volume should be updated by remote_volume
+    update_frequency: u32,
+
+    //How many samples remain until it is time to update local_volume with remote_volume.
+    samples_until_update: u32,
+}
+
+impl<I> VolumeFilter<I> where I: Source, I::Item: Sample {
+    pub fn new(source: I, remote_volume: Arc<Mutex<f32>>, update_ms: u32) -> VolumeFilter<I> {
+        let update_frequency = (update_ms * source.get_samples_rate())/1000;
+        VolumeFilter {
+            input: source,
+            local_volume: *remote_volume.lock().unwrap(),
+            remote_volume: remote_volume.clone(),
+            update_frequency: update_frequency,
+            samples_until_update: update_frequency,
+        }
+    }
+}
+
+impl<I> Iterator for VolumeFilter<I> where I: Source, I::Item: Sample {
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        self.samples_until_update -= 1;
+        if self.samples_until_update == 0 {
+            self.local_volume = *self.remote_volume.lock().unwrap();
+            self.samples_until_update = self.update_frequency;
+        }
+        let next = self.input.next();
+        if let Some(sample) = next {
+            return Some(sample.amplify(self.local_volume));
+        }
+        None
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+impl<I> Source for VolumeFilter<I> where I: Source, I::Item: Sample {
+    #[inline]
+    fn get_current_frame_len(&self) -> Option<usize> {
+        self.input.get_current_frame_len()
+    }
+
+    #[inline]
+    fn get_channels(&self) -> u16 {
+        self.input.get_channels()
+    }
+
+    #[inline]
+    fn get_samples_rate(&self) -> u32 {
+        self.input.get_samples_rate()
+    }
+
+    #[inline]
+    fn get_total_duration(&self) -> Option<Duration> {
+        self.input.get_total_duration()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@
 //!
 //! ```no_run
 //! use std::io::BufReader;
-//! 
+//!
 //! let endpoint = rodio::get_default_endpoint().unwrap();
 //! let sink = rodio::Sink::new(&endpoint);
-//! 
+//!
 //! let file = std::fs::File::open("music.ogg").unwrap();
 //! let source = rodio::Decoder::new(BufReader::new(file)).unwrap();
 //! sink.append(source);
@@ -26,23 +26,23 @@
 //! If you want to play multiple sounds simultaneously, you should create multiple sinks.
 //!
 //! # How it works
-//! 
+//!
 //! Rodio spawns a background thread that is dedicated to reading from the sources and sending
 //! the output to the endpoint.
-//! 
+//!
 //! All the sounds are mixed together by rodio before being sent. Since this is handled by the
 //! software, there is no restriction for the number of sinks that can be created.
-//! 
+//!
 //! # Adding effects
-//! 
+//!
 //! The `Source` trait provides various filters, similarly to the standard `Iterator` trait.
-//! 
+//!
 //! Example:
-//! 
+//!
 //! ```ignore
 //! use rodio::Source;
 //! use std::time::Duration;
-//! 
+//!
 //! // repeats the first five seconds of this sound forever
 //! let source = source.take_duration(Duration::from_secs(5)).repeat_infinite();
 //! ```
@@ -67,6 +67,7 @@ use std::io::{Read, Seek};
 
 mod conversions;
 mod engine;
+mod engine_filters;
 
 pub mod decoder;
 pub mod source;
@@ -103,6 +104,15 @@ impl Sink {
         self.handle.append(source);
     }
 
+    // Gets the volume of the sound.
+    ///
+    /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than 1.0 will
+    /// multiply each sample by this value.
+    #[inline]
+    pub fn volume(&self) -> f32 {
+        self.handle.volume()
+    }
+
     /// Changes the volume of the sound.
     ///
     /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than 1.0 will
@@ -110,6 +120,26 @@ impl Sink {
     #[inline]
     pub fn set_volume(&mut self, value: f32) {
         self.handle.set_volume(value);
+    }
+
+    /// Resumes playback of a paused sound.
+    #[inline]
+    pub fn play(&self) {
+        self.handle.play();
+    }
+
+    /// Pauses playback of this sink.
+    ///
+    /// A paused sound can be resumed with play
+    pub fn pause(&self) {
+        self.handle.pause();
+    }
+
+    /// Gets if a sound is paused
+    ///
+    /// Sounds can be paused and resumed using pause() and play().  This gets if a sound is paused.
+    pub fn is_paused(&self) -> bool {
+        self.handle.is_paused()
     }
 
     /// Destroys the sink without stopping the sounds that are still playing.


### PR DESCRIPTION
Implementation of https://github.com/tomaka/rodio/pull/83 using source filtering with periodic updates.  The killable implementation needed to be accessible from the engine so it was not possible to make that one simply an audio filter.  I added that functionality to the QueueIterator because those are what the engine manages in its current form.