### PR TITLE
Rename methods of the Source trait

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -56,22 +56,22 @@ impl<S> SamplesBuffer<S> where S: Sample {
 
 impl<S> Source for SamplesBuffer<S> where S: Sample {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         self.channels
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         self.samples_rate
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         Some(self.duration)
     }
 }
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn duration_basic() {
         let buf = SamplesBuffer::new(2, 2, vec![0i16, 0, 0, 0, 0, 0]);
-        let dur = buf.get_total_duration().unwrap();
+        let dur = buf.total_duration().unwrap();
         assert_eq!(dur.as_secs(), 1);
         assert_eq!(dur.subsec_nanos(), 500_000_000);
     }

--- a/src/decoder/flac.rs
+++ b/src/decoder/flac.rs
@@ -48,22 +48,22 @@ impl<R> Source for FlacDecoder<R>
     where R: Read + Seek
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         self.channels
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         self.samples_rate
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         None
     }
 }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -81,38 +81,38 @@ impl<R> Source for Decoder<R>
     where R: Read + Seek
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         match self.0 {
-            DecoderImpl::Wav(ref source) => source.get_current_frame_len(),
-            DecoderImpl::Vorbis(ref source) => source.get_current_frame_len(),
-            DecoderImpl::Flac(ref source) => source.get_current_frame_len(),
+            DecoderImpl::Wav(ref source) => source.current_frame_len(),
+            DecoderImpl::Vorbis(ref source) => source.current_frame_len(),
+            DecoderImpl::Flac(ref source) => source.current_frame_len(),
         }
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         match self.0 {
-            DecoderImpl::Wav(ref source) => source.get_channels(),
-            DecoderImpl::Vorbis(ref source) => source.get_channels(),
-            DecoderImpl::Flac(ref source) => source.get_channels(),
+            DecoderImpl::Wav(ref source) => source.channels(),
+            DecoderImpl::Vorbis(ref source) => source.channels(),
+            DecoderImpl::Flac(ref source) => source.channels(),
         }
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         match self.0 {
-            DecoderImpl::Wav(ref source) => source.get_samples_rate(),
-            DecoderImpl::Vorbis(ref source) => source.get_samples_rate(),
-            DecoderImpl::Flac(ref source) => source.get_samples_rate(),
+            DecoderImpl::Wav(ref source) => source.samples_rate(),
+            DecoderImpl::Vorbis(ref source) => source.samples_rate(),
+            DecoderImpl::Flac(ref source) => source.samples_rate(),
         }
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         match self.0 {
-            DecoderImpl::Wav(ref source) => source.get_total_duration(),
-            DecoderImpl::Vorbis(ref source) => source.get_total_duration(),
-            DecoderImpl::Flac(ref source) => source.get_total_duration(),
+            DecoderImpl::Wav(ref source) => source.total_duration(),
+            DecoderImpl::Vorbis(ref source) => source.total_duration(),
+            DecoderImpl::Flac(ref source) => source.total_duration(),
         }
     }
 }

--- a/src/decoder/vorbis.rs
+++ b/src/decoder/vorbis.rs
@@ -47,22 +47,22 @@ impl<R> Source for VorbisDecoder<R>
     where R: Read + Seek
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         Some(self.current_data.len())
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         self.stream_reader.ident_hdr.audio_channels as u16
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         self.stream_reader.ident_hdr.audio_sample_rate
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         None
     }
 }

--- a/src/decoder/wav.rs
+++ b/src/decoder/wav.rs
@@ -73,22 +73,22 @@ impl<R> Source for WavDecoder<R>
     where R: Read + Seek
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         self.channels
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         self.samples_rate
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         let ms = self.len() * 1000 / (self.channels as usize * self.samples_rate as usize);
         Some(Duration::from_millis(ms as u64))
     }

--- a/src/dynamic_mixer.rs
+++ b/src/dynamic_mixer.rs
@@ -66,22 +66,22 @@ pub struct DynamicMixer<S> {
 
 impl<S> Source for DynamicMixer<S> where S: Sample + Send + 'static {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         self.input.channels
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         self.input.samples_rate
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         None
     }
 }
@@ -142,8 +142,8 @@ mod tests {
         tx.add(SamplesBuffer::new(1, 48000, vec![10i16, -10, 10, -10]));
         tx.add(SamplesBuffer::new(1, 48000, vec![5i16, 5, 5, 5]));
 
-        assert_eq!(rx.get_channels(), 1);
-        assert_eq!(rx.get_samples_rate(), 48000);
+        assert_eq!(rx.channels(), 1);
+        assert_eq!(rx.samples_rate(), 48000);
         assert_eq!(rx.next(), Some(15));
         assert_eq!(rx.next(), Some(-5));
         assert_eq!(rx.next(), Some(15));
@@ -158,8 +158,8 @@ mod tests {
         tx.add(SamplesBuffer::new(1, 48000, vec![10i16, -10, 10, -10]));
         tx.add(SamplesBuffer::new(1, 48000, vec![5i16, 5, 5, 5]));
 
-        assert_eq!(rx.get_channels(), 2);
-        assert_eq!(rx.get_samples_rate(), 48000);
+        assert_eq!(rx.channels(), 2);
+        assert_eq!(rx.samples_rate(), 48000);
         assert_eq!(rx.next(), Some(15));
         assert_eq!(rx.next(), Some(15));
         assert_eq!(rx.next(), Some(-5));
@@ -178,8 +178,8 @@ mod tests {
         tx.add(SamplesBuffer::new(1, 48000, vec![10i16, -10, 10, -10]));
         tx.add(SamplesBuffer::new(1, 48000, vec![5i16, 5, 5, 5]));
 
-        assert_eq!(rx.get_channels(), 1);
-        assert_eq!(rx.get_samples_rate(), 96000);
+        assert_eq!(rx.channels(), 1);
+        assert_eq!(rx.samples_rate(), 96000);
         assert_eq!(rx.next(), Some(15));
         assert_eq!(rx.next(), Some(5));
         assert_eq!(rx.next(), Some(-5));

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -95,11 +95,11 @@ pub struct SourcesQueueOutput<S> {
 
 impl<S> Source for SourcesQueueOutput<S> where S: Sample + Send + 'static {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         // This function is non-trivial because the boundary between two sounds in the queue should
         // be a frame boundary as well.
         //
-        // The current sound is free to return `None` for `get_current_frame_len()`, in which case
+        // The current sound is free to return `None` for `current_frame_len()`, in which case
         // we *should* return the number of samples remaining the current sound.
         // This can be estimated with `size_hint()`.
         //
@@ -108,8 +108,8 @@ impl<S> Source for SourcesQueueOutput<S> where S: Sample + Send + 'static {
         // constant.
         const THRESHOLD: usize = 10240;
 
-        // Try the current `get_current_frame_len`.
-        if let Some(val) = self.current.get_current_frame_len() {
+        // Try the current `current_frame_len`.
+        if let Some(val) = self.current.current_frame_len() {
             if val != 0 {
                 return Some(val);
             }
@@ -127,17 +127,17 @@ impl<S> Source for SourcesQueueOutput<S> where S: Sample + Send + 'static {
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.current.get_channels()
+    fn channels(&self) -> u16 {
+        self.current.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.current.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.current.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         None
     }
 }
@@ -213,14 +213,14 @@ mod tests {
         tx.append(SamplesBuffer::new(1, 48000, vec![10i16, -10, 10, -10]));
         tx.append(SamplesBuffer::new(2, 96000, vec![5i16, 5, 5, 5]));
 
-        assert_eq!(rx.get_channels(), 1);
-        assert_eq!(rx.get_samples_rate(), 48000);
+        assert_eq!(rx.channels(), 1);
+        assert_eq!(rx.samples_rate(), 48000);
         assert_eq!(rx.next(), Some(10));
         assert_eq!(rx.next(), Some(-10));
         assert_eq!(rx.next(), Some(10));
         assert_eq!(rx.next(), Some(-10));
-        assert_eq!(rx.get_channels(), 2);
-        assert_eq!(rx.get_samples_rate(), 96000);
+        assert_eq!(rx.channels(), 2);
+        assert_eq!(rx.samples_rate(), 96000);
         assert_eq!(rx.next(), Some(5));
         assert_eq!(rx.next(), Some(5));
         assert_eq!(rx.next(), Some(5));

--- a/src/source/amplify.rs
+++ b/src/source/amplify.rs
@@ -52,22 +52,22 @@ impl<I> Source for Amplify<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.input.get_current_frame_len()
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        self.input.get_total_duration()
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
     }
 }

--- a/src/source/buffered.rs
+++ b/src/source/buffered.rs
@@ -11,7 +11,7 @@ pub fn buffered<I>(input: I) -> Buffered<I>
     where I: Source,
           I::Item: Sample
 {
-    let total_duration = input.get_total_duration();
+    let total_duration = input.total_duration();
     let first_frame = extract(input);
 
     Buffered {
@@ -67,14 +67,14 @@ fn extract<I>(mut input: I) -> Arc<Frame<I>>
     where I: Source,
           I::Item: Sample
 {
-    let frame_len = input.get_current_frame_len();
+    let frame_len = input.current_frame_len();
 
     if frame_len == Some(0) {
         return Arc::new(Frame::End);
     }
 
-    let channels = input.get_channels();
-    let rate = input.get_samples_rate();
+    let channels = input.channels();
+    let rate = input.samples_rate();
     let data = input.by_ref().take(cmp::min(frame_len.unwrap_or(32768), 32768)).collect();
 
     Arc::new(Frame::Data(FrameData {
@@ -165,7 +165,7 @@ impl<I> Source for Buffered<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         match &*self.current_frame {
             &Frame::Data(FrameData { ref data, .. }) => Some(data.len() - self.position_in_frame),
             &Frame::End => Some(0),
@@ -174,7 +174,7 @@ impl<I> Source for Buffered<I>
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         match &*self.current_frame {
             &Frame::Data(FrameData { channels, .. }) => channels,
             &Frame::End => 1,
@@ -183,7 +183,7 @@ impl<I> Source for Buffered<I>
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         match &*self.current_frame {
             &Frame::Data(FrameData { rate, .. }) => rate,
             &Frame::End => 44100,
@@ -192,7 +192,7 @@ impl<I> Source for Buffered<I>
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         self.total_duration
     }
 }

--- a/src/source/delay.rs
+++ b/src/source/delay.rs
@@ -9,7 +9,7 @@ pub fn delay<I>(input: I, duration: Duration) -> Delay<I>
           I::Item: Sample
 {
     let duration_ns = duration.as_secs() * 1000000000 + duration.subsec_nanos() as u64;
-    let samples = duration_ns * input.get_samples_rate() as u64 * input.get_channels() as u64 /
+    let samples = duration_ns * input.samples_rate() as u64 * input.channels() as u64 /
                   1000000000;
 
     Delay {
@@ -59,22 +59,22 @@ impl<I> Source for Delay<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.input.get_current_frame_len().map(|val| val + self.remaining_samples)
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len().map(|val| val + self.remaining_samples)
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        self.input.get_total_duration().map(|val| val + self.requested_duration)
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration().map(|val| val + self.requested_duration)
     }
 }

--- a/src/source/empty.rs
+++ b/src/source/empty.rs
@@ -25,22 +25,22 @@ impl<S> Iterator for Empty<S> {
 
 impl<S> Source for Empty<S> where S: Sample {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         1
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         48000
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         Some(Duration::new(0, 0))
     }
 }

--- a/src/source/fadein.rs
+++ b/src/source/fadein.rs
@@ -42,7 +42,7 @@ impl<I> Iterator for FadeIn<I>
 
         let factor = 1.0 - self.remaining_ns / self.total_ns;
         self.remaining_ns -= 1000000000.0 /
-                             (self.input.get_samples_rate() as f32 * self.get_channels() as f32);
+                             (self.input.samples_rate() as f32 * self.channels() as f32);
         self.input.next().map(|value| value.amplify(factor))
     }
 
@@ -63,22 +63,22 @@ impl<I> Source for FadeIn<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.input.get_current_frame_len()
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        self.input.get_total_duration()
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
     }
 }

--- a/src/source/mix.rs
+++ b/src/source/mix.rs
@@ -13,8 +13,8 @@ pub fn mix<I1, I2>(input1: I1, input2: I2) -> Mix<I1, I2>
           I2: Source,
           I2::Item: Sample
 {
-    let channels = input1.get_channels();
-    let rate = input1.get_samples_rate();
+    let channels = input1.channels();
+    let rate = input1.samples_rate();
 
     Mix {
         input1: UniformSourceIterator::new(input1, channels, rate),
@@ -85,9 +85,9 @@ impl<I1, I2> Source for Mix<I1, I2>
           I2::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        let f1 = self.input1.get_current_frame_len();
-        let f2 = self.input2.get_current_frame_len();
+    fn current_frame_len(&self) -> Option<usize> {
+        let f1 = self.input1.current_frame_len();
+        let f2 = self.input2.current_frame_len();
 
         match (f1, f2) {
             (Some(f1), Some(f2)) => Some(cmp::min(f1, f2)),
@@ -96,19 +96,19 @@ impl<I1, I2> Source for Mix<I1, I2>
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input1.get_channels()
+    fn channels(&self) -> u16 {
+        self.input1.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input1.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input1.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        let f1 = self.input1.get_total_duration();
-        let f2 = self.input2.get_total_duration();
+    fn total_duration(&self) -> Option<Duration> {
+        let f1 = self.input1.total_duration();
+        let f2 = self.input2.total_duration();
 
         match (f1, f2) {
             (Some(f1), Some(f2)) => Some(cmp::max(f1, f2)),

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -83,8 +83,8 @@ mod zero;
 ///
 /// The three characteristics that describe a sound are provided through this trait:
 ///
-/// - The number of channels can be retreived with `get_channels`.
-/// - The frequency can be retreived with `get_samples_rate`.
+/// - The number of channels can be retreived with `channels`.
+/// - The frequency can be retreived with `samples_rate`.
 /// - The list of values can be retreived by iterating on the source. The `Source` trait requires
 ///   that the `Iterator` trait be implemented as well.
 ///
@@ -98,10 +98,10 @@ mod zero;
 /// > transition between the two files.
 ///
 /// However, for optimization purposes rodio supposes that the number of channels and the frequency
-/// stay the same for long periods of time and avoids calling `get_channels()` and
-/// `get_samples_rate` too frequently.
+/// stay the same for long periods of time and avoids calling `channels()` and
+/// `samples_rate` too frequently.
 ///
-/// In order to properly handle this situation, the `get_current_frame_len()` method should return
+/// In order to properly handle this situation, the `current_frame_len()` method should return
 /// the number of samples that remain in the iterator before the samples rate and number of
 /// channels can potentially change.
 ///
@@ -113,19 +113,19 @@ pub trait Source: Iterator
     /// Should never return 0 unless there's no more data.
     ///
     /// After the engine has finished reading the specified number of samples, it will check
-    /// whether the value of `get_channels()` and/or `get_samples_rate()` have changed.
-    fn get_current_frame_len(&self) -> Option<usize>;
+    /// whether the value of `channels()` and/or `samples_rate()` have changed.
+    fn current_frame_len(&self) -> Option<usize>;
 
     /// Returns the number of channels. Channels are always interleaved.
-    fn get_channels(&self) -> u16;
+    fn channels(&self) -> u16;
 
     /// Returns the rate at which the source should be played. In number of samples per second.
-    fn get_samples_rate(&self) -> u32;
+    fn samples_rate(&self) -> u32;
 
     /// Returns the total duration of this source, if known.
     ///
     /// `None` indicates at the same time "infinite" or "unknown".
-    fn get_total_duration(&self) -> Option<Duration>;
+    fn total_duration(&self) -> Option<Duration>;
 
     /// Stores the source in a buffer in addition to returning it. This iterator can be cloned.
     #[inline]

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -32,7 +32,7 @@ impl<I> Pausable<I>
 {
     pub fn new(source: I, remote_paused: Arc<AtomicBool>, update_ms: u32) -> Pausable<I> {
         // TODO: handle the fact that the samples rate can change
-        let update_frequency = (update_ms * source.get_samples_rate()) / 1000;
+        let update_frequency = (update_ms * source.samples_rate()) / 1000;
         Pausable {
             input: source,
             local_paused: remote_paused.load(Ordering::Relaxed),
@@ -73,22 +73,22 @@ impl<I> Source for Pausable<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.input.get_current_frame_len()
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        self.input.get_total_duration()
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
     }
 }

--- a/src/source/repeat.rs
+++ b/src/source/repeat.rs
@@ -55,31 +55,31 @@ impl<I> Source for Repeat<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        match self.inner.get_current_frame_len() {
-            Some(0) => self.next.get_current_frame_len(),
+    fn current_frame_len(&self) -> Option<usize> {
+        match self.inner.current_frame_len() {
+            Some(0) => self.next.current_frame_len(),
             a => a,
         }
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        match self.inner.get_current_frame_len() {
-            Some(0) => self.next.get_channels(),
-            _ => self.inner.get_channels(),
+    fn channels(&self) -> u16 {
+        match self.inner.current_frame_len() {
+            Some(0) => self.next.channels(),
+            _ => self.inner.channels(),
         }
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        match self.inner.get_current_frame_len() {
-            Some(0) => self.next.get_samples_rate(),
-            _ => self.inner.get_samples_rate(),
+    fn samples_rate(&self) -> u32 {
+        match self.inner.current_frame_len() {
+            Some(0) => self.next.samples_rate(),
+            _ => self.inner.samples_rate(),
         }
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         None
     }
 }

--- a/src/source/samples_converter.rs
+++ b/src/source/samples_converter.rs
@@ -64,22 +64,22 @@ impl<I, D> Source for SamplesConverter<I, D>
           D: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.inner.get_current_frame_len()
+    fn current_frame_len(&self) -> Option<usize> {
+        self.inner.current_frame_len()
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.inner.get_channels()
+    fn channels(&self) -> u16 {
+        self.inner.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.inner.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.inner.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        self.inner.get_total_duration()
+    fn total_duration(&self) -> Option<Duration> {
+        self.inner.total_duration()
     }
 }

--- a/src/source/sine.rs
+++ b/src/source/sine.rs
@@ -35,22 +35,22 @@ impl Iterator for SineWave {
 
 impl Source for SineWave {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         1
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         48000
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         None
     }
 }

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -52,24 +52,24 @@ impl<I> Source for Speed<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.input.get_current_frame_len()
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        (self.input.get_samples_rate() as f32 * self.factor) as u32
+    fn samples_rate(&self) -> u32 {
+        (self.input.samples_rate() as f32 * self.factor) as u32
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         // TODO: the crappy API of duration makes this code difficult to write
-        if let Some(duration) = self.input.get_total_duration() {
+        if let Some(duration) = self.input.total_duration() {
             let as_ns = duration.as_secs() * 1000000000 + duration.subsec_nanos() as u64;
             let new_val = (as_ns as f32 / self.factor) as u64;
             Some(Duration::new(new_val / 1000000000, (new_val % 1000000000) as u32))

--- a/src/source/stoppable.rs
+++ b/src/source/stoppable.rs
@@ -29,7 +29,7 @@ impl<I> Stoppable<I>
 {
     pub fn new(source: I, remote_stopped: Arc<AtomicBool>, update_ms: u32) -> Stoppable<I> {
         // TODO: handle the fact that the samples rate can change
-        let update_frequency = (update_ms * source.get_samples_rate()) / 1000;
+        let update_frequency = (update_ms * source.samples_rate()) / 1000;
         Stoppable {
             input: source,
             remote_stopped: remote_stopped,
@@ -71,22 +71,22 @@ impl<I> Source for Stoppable<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.input.get_current_frame_len()
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        self.input.get_total_duration()
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
     }
 }

--- a/src/source/take.rs
+++ b/src/source/take.rs
@@ -33,7 +33,7 @@ impl<I> TakeDuration<I>
     /// Returns the duration elapsed for each sample extracted.
     #[inline]
     fn get_duration_per_sample(&self) -> Duration {
-        let ns = 1000000000 / (self.input.get_samples_rate() as u64 * self.get_channels() as u64);
+        let ns = 1000000000 / (self.input.samples_rate() as u64 * self.channels() as u64);
         // \|/ the maximum value of `ns` is one billion, so this can't fail
         Duration::new(0, ns as u32)
     }
@@ -70,12 +70,12 @@ impl<I> Source for TakeDuration<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        if let Some(value) = self.input.get_current_frame_len() {
+    fn current_frame_len(&self) -> Option<usize> {
+        if let Some(value) = self.input.current_frame_len() {
             let remaining_nanosecs = self.remaining_duration.as_secs() * 1000000000 +
                                      self.remaining_duration.subsec_nanos() as u64;
-            let remaining_samples = remaining_nanosecs * self.input.get_samples_rate() as u64 *
-                                    self.get_channels() as u64 /
+            let remaining_samples = remaining_nanosecs * self.input.samples_rate() as u64 *
+                                    self.channels() as u64 /
                                     1000000000;
 
             if (value as u64) < remaining_samples {
@@ -90,18 +90,18 @@ impl<I> Source for TakeDuration<I>
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        if let Some(duration) = self.input.get_total_duration() {
+    fn total_duration(&self) -> Option<Duration> {
+        if let Some(duration) = self.input.total_duration() {
             if duration < self.requested_duration {
                 Some(duration)
             } else {

--- a/src/source/uniform.rs
+++ b/src/source/uniform.rs
@@ -37,7 +37,7 @@ impl<I, D> UniformSourceIterator<I, D>
                target_channels: u16,
                target_samples_rate: u32)
                -> UniformSourceIterator<I, D> {
-        let total_duration = input.get_total_duration();
+        let total_duration = input.total_duration();
         let input = UniformSourceIterator::bootstrap(input, target_channels, target_samples_rate);
 
         UniformSourceIterator {
@@ -53,10 +53,10 @@ impl<I, D> UniformSourceIterator<I, D>
                  target_channels: u16,
                  target_samples_rate: u32)
                  -> DataConverter<ChannelsCountConverter<SamplesRateConverter<Take<I>>>, D> {
-        let frame_len = input.get_current_frame_len();
+        let frame_len = input.current_frame_len();
 
-        let from_channels = input.get_channels();
-        let from_samples_rate = input.get_samples_rate();
+        let from_channels = input.channels();
+        let from_samples_rate = input.samples_rate();
 
         let input = Take {
             iter: input,
@@ -107,22 +107,22 @@ impl<I, D> Source for UniformSourceIterator<I, D>
           D: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         self.target_channels
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         self.target_samples_rate
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         self.total_duration
     }
 }

--- a/src/source/volume_filter.rs
+++ b/src/source/volume_filter.rs
@@ -32,7 +32,7 @@ impl<I> VolumeFilter<I>
 {
     pub fn new(source: I, remote_volume: Arc<Mutex<f32>>, update_ms: u32) -> VolumeFilter<I> {
         // TODO: handle the fact that the samples rate can change
-        let update_frequency = (update_ms * source.get_samples_rate()) / 1000;
+        let update_frequency = (update_ms * source.samples_rate()) / 1000;
         VolumeFilter {
             input: source,
             local_volume: *remote_volume.lock().unwrap(),
@@ -74,22 +74,22 @@ impl<I> Source for VolumeFilter<I>
           I::Item: Sample
 {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
-        self.input.get_current_frame_len()
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
-        self.input.get_channels()
+    fn channels(&self) -> u16 {
+        self.input.channels()
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
-        self.input.get_samples_rate()
+    fn samples_rate(&self) -> u32 {
+        self.input.samples_rate()
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
-        self.input.get_total_duration()
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
     }
 }

--- a/src/source/zero.rs
+++ b/src/source/zero.rs
@@ -33,22 +33,22 @@ impl<S> Iterator for Zero<S> where S: Sample {
 
 impl<S> Source for Zero<S> where S: Sample {
     #[inline]
-    fn get_current_frame_len(&self) -> Option<usize> {
+    fn current_frame_len(&self) -> Option<usize> {
         None
     }
 
     #[inline]
-    fn get_channels(&self) -> u16 {
+    fn channels(&self) -> u16 {
         self.channels
     }
 
     #[inline]
-    fn get_samples_rate(&self) -> u32 {
+    fn samples_rate(&self) -> u32 {
         self.samples_rate
     }
 
     #[inline]
-    fn get_total_duration(&self) -> Option<Duration> {
+    fn total_duration(&self) -> Option<Duration> {
         None
     }
 }


### PR DESCRIPTION
Removes the `get_` prefix from methods of the `Source` trait.

This is a breaking change that I've been waiting to do for a long time, and since there are other breaking changes already in we might as well do this one.
