### PR TITLE
fix 'index out of bounds'

### DIFF
--- a/src/source/buffered.rs
+++ b/src/source/buffered.rs
@@ -75,10 +75,14 @@ fn extract<I>(mut input: I) -> Arc<Frame<I>>
 
     let channels = input.channels();
     let rate = input.samples_rate();
-    let data = input
+    let data : Vec<I::Item> = input
         .by_ref()
         .take(cmp::min(frame_len.unwrap_or(32768), 32768))
         .collect();
+
+    if data.is_empty() {
+        return Arc::new(Frame::End);
+    }
 
     Arc::new(Frame::Data(FrameData {
                              data: data,


### PR DESCRIPTION
`SamplesBuffer` for `current_frame_length` returns `None`, so `Buffered` will never be `Frame::End` and this code will panic:
```
extern crate rodio;

fn main() {
    use rodio::Source;
    rodio::buffer::SamplesBuffer::new(1, 44100, vec![0.0]).buffered().count();
}
```