### PR TITLE
Publish new version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "Apache-2.0"
 description = "Audio playback library"


### PR DESCRIPTION
It would be helpful to me to have use of the new `empty()` function for Amethyst.  Do you mind publishing a new minor version?