### PR TITLE
make sure buffer doesn't contain garbage

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -141,18 +141,18 @@ fn new_voice(endpoint: &Endpoint, events_loop: &Arc<EventLoop>)
     let future_to_exec = stream.for_each(move |mut buffer| -> Result<_, ()> {
         match buffer {
             UnknownTypeBuffer::U16(ref mut buffer) => {
-                for (o, i) in buffer.iter_mut().zip(mixer_rx.by_ref()) {
-                    *o = i.to_u16();
+                for d in buffer.iter_mut() {
+                    *d = mixer_rx.next().map(|s| s.to_u16()).unwrap_or(0u16);
                 }
             },
             UnknownTypeBuffer::I16(ref mut buffer) => {
-                for (o, i) in buffer.iter_mut().zip(mixer_rx.by_ref()) {
-                    *o = i.to_i16();
+                for d in buffer.iter_mut() {
+                    *d = mixer_rx.next().map(|s| s.to_i16()).unwrap_or(0i16);
                 }
             },
             UnknownTypeBuffer::F32(ref mut buffer) => {
-                for (o, i) in buffer.iter_mut().zip(mixer_rx.by_ref()) {
-                    *o = i;
+                for d in buffer.iter_mut() {
+                    *d = mixer_rx.next().unwrap_or(0f32);
                 }
             },
         };


### PR DESCRIPTION
This fixes #132.

Given `buffer` is obtained from `IAudioRenderClient::GetBuffer` and may contain garbage (previous sound for example). `IAudioRenderClient::ReleaseBuffer` currently always returns whole buffer (in `cpal`) no matter if we filled it completely or partially or none, so we have to be sure it is filled with correct data.

My test code:
```rust
extern crate rodio;

use std::time::Duration;
use rodio::Source;

fn main() {
    let endpoint = rodio::get_default_endpoint().unwrap();
    let mut sink = rodio::Sink::new(&endpoint);
    sink.set_volume(0.1);

    let source = rodio::source::SineWave::new(440).take_duration(Duration::from_secs(10));

    println!("start 10 sec of sound");
    sink.append(source);

    std::thread::sleep(Duration::from_secs(1));

    println!("detach after 1 sec");
    sink.detach();

    std::thread::sleep(Duration::from_secs(9));

    println!("silence");

    std::thread::sleep(Duration::from_secs(100));
}
```