### PR TITLE
Replace usages of deprecated functions in cpal

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::get_default_endpoint().unwrap();
+    let endpoint = rodio::default_endpoint().unwrap();
 
     let file = std::fs::File::open("examples/beep.wav").unwrap();
     let mut beep1 = rodio::play_once(&endpoint, BufReader::new(file)).unwrap();

--- a/examples/music_flac.rs
+++ b/examples/music_flac.rs
@@ -3,7 +3,7 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::get_default_endpoint().unwrap();
+    let endpoint = rodio::default_endpoint().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.flac").unwrap();

--- a/examples/music_ogg.rs
+++ b/examples/music_ogg.rs
@@ -3,7 +3,7 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::get_default_endpoint().unwrap();
+    let endpoint = rodio::default_endpoint().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.ogg").unwrap();

--- a/examples/music_wav.rs
+++ b/examples/music_wav.rs
@@ -3,7 +3,7 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::get_default_endpoint().unwrap();
+    let endpoint = rodio::default_endpoint().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.wav").unwrap();

--- a/examples/reverb.rs
+++ b/examples/reverb.rs
@@ -5,7 +5,7 @@ use std::io::BufReader;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::get_default_endpoint().unwrap();
+    let endpoint = rodio::default_endpoint().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.ogg").unwrap();

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::get_default_endpoint().unwrap();
+    let endpoint = rodio::default_endpoint().unwrap();
     let mut sink = rodio::SpatialSink::new(&endpoint,
                                            [-10.0, 0.0, 0.0],
                                            [1.0, 0.0, 0.0],

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -71,7 +71,7 @@ impl Engine {
         let mixer = {
             let mut end_points = self.end_points.lock().unwrap();
 
-            match end_points.entry(endpoint.get_name()) {
+            match end_points.entry(endpoint.name()) {
                 Entry::Vacant(e) => {
                     let (mixer, voice) = new_voice(endpoint, &self.events_loop);
                     e.insert(Arc::downgrade(&mixer));
@@ -104,7 +104,7 @@ fn new_voice(endpoint: &Endpoint, events_loop: &Arc<EventLoop>)
              -> (Arc<dynamic_mixer::DynamicMixerController<f32>>, Voice) {
     // Determine the format to use for the new voice.
     let format = endpoint
-        .get_supported_formats_list()
+        .supported_formats()
         .unwrap()
         .fold(None, |f1, f2| {
             if f1.is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //! - Create an object that represents the streaming sound. It can be a sine wave, a buffer, a
 //!   [decoder](decoder/index.html), etc. or even your own type that implements
 //!   [the `Source` trait](source/trait.Source.html).
-//! - Choose an output with the [`get_endpoints_list`](fn.get_endpoints_list.html) or
-//!   [`get_default_endpoint`](fn.get_default_endpoint.html) functions.
+//! - Choose an output with the [`endpoints`](fn.endpoints.html) or
+//!   [`default_endpoint`](fn.default_endpoint.html) functions.
 //! - Call [`play_raw(output, source)`](fn.play_raw.html).
 //!
 //! The `play_raw` function expects the source to produce `f32`s, which may not be the case. If you
@@ -20,7 +20,7 @@
 //! use std::io::BufReader;
 //! use rodio::Source;
 //!
-//! let endpoint = rodio::get_default_endpoint().unwrap();
+//! let endpoint = rodio::default_endpoint().unwrap();
 //!
 //! let file = File::open("sound.ogg").unwrap();
 //! let source = rodio::Decoder::new(BufReader::new(file)).unwrap();
@@ -38,7 +38,7 @@
 //! ```no_run
 //! use rodio::Sink;
 //!
-//! let endpoint = rodio::get_default_endpoint().unwrap();
+//! let endpoint = rodio::default_endpoint().unwrap();
 //! let sink = Sink::new(&endpoint);
 //!
 //! // Add a dummy source of the sake of the example.
@@ -92,7 +92,7 @@ extern crate lazy_static;
 extern crate lewton;
 extern crate cgmath;
 
-pub use cpal::{Endpoint, get_default_endpoint, get_endpoints_list};
+pub use cpal::{Endpoint, default_endpoint, endpoints, get_default_endpoint, get_endpoints_list};
 
 pub use conversions::Sample;
 pub use decoder::Decoder;


### PR DESCRIPTION
I get deprecation warnings from cpal when using rodio. This adds `pub use` of the non-deprecated functions, and also replaces some internal/example usages of deprecated methods.

I've run the tests and the examples and everything still works, although the FLAC playback is really choppy on my machine for some reason.