### PR TITLE
Optional decoders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,17 @@ repository = "https://github.com/tomaka/rodio"
 documentation = "http://docs.rs/rodio"
 
 [dependencies]
-claxon = "0.3.0"
+claxon = { version = "0.3.0", optional = true }
 cpal = "0.4.0"
 futures = "0.1.1"
-hound = "1.0.0"
+hound = { version = "1.0.0", optional = true }
 lazy_static = "0.1.12"
-lewton = "0.5"
+lewton = { version = "0.5", optional = true }
 cgmath = "0.14"
+
+[features]
+default = ["flac", "vorbis", "wav"]
+
+flac = ["claxon"]
+vorbis = ["lewton"]
+wav = ["hound"]

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -17,8 +17,13 @@ mod wav;
 /// Source of audio samples from decoding a file.
 ///
 /// Supports WAV, Vorbis and Flac.
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 pub struct Decoder<R>(DecoderImpl<R>) where R: Read + Seek;
 
+#[cfg(not(any(feature = "wav", feature = "flac", feature = "vorbis")))]
+pub struct Decoder<R>(::std::marker::PhantomData<R>);
+
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 enum DecoderImpl<R>
     where R: Read + Seek
 {
@@ -66,7 +71,16 @@ impl<R> Decoder<R>
     }
 }
 
+#[cfg(not(any(feature = "wav", feature = "flac", feature = "vorbis")))]
+impl<R> Iterator for Decoder<R>
+    where R: Read + Seek
+{
+    type Item = i16;
 
+    fn next(&mut self) -> Option<i16> { None }
+}
+
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 impl<R> Iterator for Decoder<R>
     where R: Read + Seek
 {
@@ -97,6 +111,17 @@ impl<R> Iterator for Decoder<R>
     }
 }
 
+#[cfg(not(any(feature = "wav", feature = "flac", feature = "vorbis")))]
+impl<R> Source for Decoder<R>
+    where R: Read + Seek
+{
+    fn current_frame_len(&self) -> Option<usize> { Some(0) }
+    fn channels(&self) -> u16 { 0 }
+    fn samples_rate(&self) -> u32 { 1 }
+    fn total_duration(&self) -> Option<Duration> { Some(Duration::default()) }
+}
+
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 impl<R> Source for Decoder<R>
     where R: Read + Seek
 {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -7,8 +7,11 @@ use std::time::Duration;
 
 use Source;
 
+#[cfg(feature = "flac")]
 mod flac;
+#[cfg(feature = "vorbis")]
 mod vorbis;
+#[cfg(feature = "wav")]
 mod wav;
 
 /// Source of audio samples from decoding a file.
@@ -19,8 +22,11 @@ pub struct Decoder<R>(DecoderImpl<R>) where R: Read + Seek;
 enum DecoderImpl<R>
     where R: Read + Seek
 {
+    #[cfg(feature = "wav")]
     Wav(wav::WavDecoder<R>),
+    #[cfg(feature = "vorbis")]
     Vorbis(vorbis::VorbisDecoder<R>),
+    #[cfg(feature = "flac")]
     Flac(flac::FlacDecoder<R>),
 }
 
@@ -30,28 +36,35 @@ impl<R> Decoder<R>
     /// Builds a new decoder.
     ///
     /// Attempts to automatically detect the format of the source of data.
-    pub fn new(data: R) -> Result<Decoder<R>, DecoderError> {
-        let data = match wav::WavDecoder::new(data) {
-            Err(data) => data,
+    pub fn new(_data: R) -> Result<Decoder<R>, DecoderError> {
+        #[cfg(feature = "wav")]
+        let _data = match wav::WavDecoder::new(_data) {
+            Err(_data) => _data,
             Ok(decoder) => {
                 return Ok(Decoder(DecoderImpl::Wav(decoder)));
             },
         };
 
-        let data = match flac::FlacDecoder::new(data) {
-            Err(data) => data,
+        #[cfg(feature = "flac")]
+        let _data = match flac::FlacDecoder::new(_data) {
+            Err(_data) => _data,
             Ok(decoder) => {
                 return Ok(Decoder(DecoderImpl::Flac(decoder)));
             },
         };
 
-        if let Ok(decoder) = vorbis::VorbisDecoder::new(data) {
-            return Ok(Decoder(DecoderImpl::Vorbis(decoder)));
-        }
+        #[cfg(feature = "vorbis")]
+        let _data = match vorbis::VorbisDecoder::new(_data) {
+            Err(_data) => _data,
+            Ok(decoder) => {
+                return Ok(Decoder(DecoderImpl::Vorbis(decoder)));
+            },
+        };
 
         Err(DecoderError::UnrecognizedFormat)
     }
 }
+
 
 impl<R> Iterator for Decoder<R>
     where R: Read + Seek
@@ -61,8 +74,11 @@ impl<R> Iterator for Decoder<R>
     #[inline]
     fn next(&mut self) -> Option<i16> {
         match self.0 {
+            #[cfg(feature = "wav")]
             DecoderImpl::Wav(ref mut source) => source.next(),
+            #[cfg(feature = "vorbis")]
             DecoderImpl::Vorbis(ref mut source) => source.next(),
+            #[cfg(feature = "flac")]
             DecoderImpl::Flac(ref mut source) => source.next(),
         }
     }
@@ -70,8 +86,11 @@ impl<R> Iterator for Decoder<R>
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.0 {
+            #[cfg(feature = "wav")]
             DecoderImpl::Wav(ref source) => source.size_hint(),
+            #[cfg(feature = "vorbis")]
             DecoderImpl::Vorbis(ref source) => source.size_hint(),
+            #[cfg(feature = "flac")]
             DecoderImpl::Flac(ref source) => source.size_hint(),
         }
     }
@@ -83,8 +102,11 @@ impl<R> Source for Decoder<R>
     #[inline]
     fn current_frame_len(&self) -> Option<usize> {
         match self.0 {
+            #[cfg(feature = "wav")]
             DecoderImpl::Wav(ref source) => source.current_frame_len(),
+            #[cfg(feature = "vorbis")]
             DecoderImpl::Vorbis(ref source) => source.current_frame_len(),
+            #[cfg(feature = "flac")]
             DecoderImpl::Flac(ref source) => source.current_frame_len(),
         }
     }
@@ -92,8 +114,11 @@ impl<R> Source for Decoder<R>
     #[inline]
     fn channels(&self) -> u16 {
         match self.0 {
+            #[cfg(feature = "wav")]
             DecoderImpl::Wav(ref source) => source.channels(),
+            #[cfg(feature = "vorbis")]
             DecoderImpl::Vorbis(ref source) => source.channels(),
+            #[cfg(feature = "flac")]
             DecoderImpl::Flac(ref source) => source.channels(),
         }
     }
@@ -101,8 +126,11 @@ impl<R> Source for Decoder<R>
     #[inline]
     fn samples_rate(&self) -> u32 {
         match self.0 {
+            #[cfg(feature = "wav")]
             DecoderImpl::Wav(ref source) => source.samples_rate(),
+            #[cfg(feature = "vorbis")]
             DecoderImpl::Vorbis(ref source) => source.samples_rate(),
+            #[cfg(feature = "flac")]
             DecoderImpl::Flac(ref source) => source.samples_rate(),
         }
     }
@@ -110,8 +138,11 @@ impl<R> Source for Decoder<R>
     #[inline]
     fn total_duration(&self) -> Option<Duration> {
         match self.0 {
+            #[cfg(feature = "wav")]
             DecoderImpl::Wav(ref source) => source.total_duration(),
+            #[cfg(feature = "vorbis")]
             DecoderImpl::Vorbis(ref source) => source.total_duration(),
+            #[cfg(feature = "flac")]
             DecoderImpl::Flac(ref source) => source.total_duration(),
         }
     }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -36,26 +36,27 @@ impl<R> Decoder<R>
     /// Builds a new decoder.
     ///
     /// Attempts to automatically detect the format of the source of data.
-    pub fn new(_data: R) -> Result<Decoder<R>, DecoderError> {
+    #[allow(unused_variables)]
+    pub fn new(data: R) -> Result<Decoder<R>, DecoderError> {
         #[cfg(feature = "wav")]
-        let _data = match wav::WavDecoder::new(_data) {
-            Err(_data) => _data,
+        let data = match wav::WavDecoder::new(data) {
+            Err(data) => data,
             Ok(decoder) => {
                 return Ok(Decoder(DecoderImpl::Wav(decoder)));
             },
         };
 
         #[cfg(feature = "flac")]
-        let _data = match flac::FlacDecoder::new(_data) {
-            Err(_data) => _data,
+        let data = match flac::FlacDecoder::new(data) {
+            Err(data) => data,
             Ok(decoder) => {
                 return Ok(Decoder(DecoderImpl::Flac(decoder)));
             },
         };
 
         #[cfg(feature = "vorbis")]
-        let _data = match vorbis::VorbisDecoder::new(_data) {
-            Err(_data) => _data,
+        let data = match vorbis::VorbisDecoder::new(data) {
+            Err(data) => data,
             Ok(decoder) => {
                 return Ok(Decoder(DecoderImpl::Vorbis(decoder)));
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,14 +97,12 @@ extern crate cgmath;
 pub use cpal::{Endpoint, default_endpoint, endpoints, get_default_endpoint, get_endpoints_list};
 
 pub use conversions::Sample;
-#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 pub use decoder::Decoder;
 pub use engine::play_raw;
 pub use sink::Sink;
 pub use source::Source;
 pub use spatial_sink::SpatialSink;
 
-#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 use std::io::{Read, Seek};
 
 mod conversions;
@@ -113,7 +111,6 @@ mod sink;
 mod spatial_sink;
 
 pub mod buffer;
-#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 pub mod decoder;
 pub mod dynamic_mixer;
 pub mod queue;
@@ -121,7 +118,6 @@ pub mod source;
 
 /// Plays a sound once. Returns a `Sink` that can be used to control the sound.
 #[inline]
-#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 pub fn play_once<R>(endpoint: &Endpoint, input: R) -> Result<Sink, decoder::DecoderError>
     where R: Read + Seek + Send + 'static
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,24 +83,29 @@
 
 #![cfg_attr(test, deny(missing_docs))]
 
+#[cfg(feature = "flac")]
 extern crate claxon;
 extern crate cpal;
 extern crate futures;
+#[cfg(feature = "wav")]
 extern crate hound;
 #[macro_use]
 extern crate lazy_static;
+#[cfg(feature = "vorbis")]
 extern crate lewton;
 extern crate cgmath;
 
 pub use cpal::{Endpoint, get_default_endpoint, get_endpoints_list};
 
 pub use conversions::Sample;
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 pub use decoder::Decoder;
 pub use engine::play_raw;
 pub use sink::Sink;
 pub use source::Source;
 pub use spatial_sink::SpatialSink;
 
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 use std::io::{Read, Seek};
 
 mod conversions;
@@ -109,6 +114,7 @@ mod sink;
 mod spatial_sink;
 
 pub mod buffer;
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 pub mod decoder;
 pub mod dynamic_mixer;
 pub mod queue;
@@ -116,6 +122,7 @@ pub mod source;
 
 /// Plays a sound once. Returns a `Sink` that can be used to control the sound.
 #[inline]
+#[cfg(any(feature = "wav", feature = "flac", feature = "vorbis"))]
 pub fn play_once<R>(endpoint: &Endpoint, input: R) -> Result<Sink, decoder::DecoderError>
     where R: Read + Seek + Send + 'static
 {


### PR DESCRIPTION
This PR adds ability to turn off unwanted decoders and their dependencies. (`wav/hound`, `vorbis/lewton`, `flac/claxon`). Can be useful if you use `rodio` with one format only and don't need any extra. It is also valid to turn off all decoding capabilities. By default all three are turned on.
(Similar thing is possible in `image` crate, I used it there and thought it may be useful for `rodio` as well)