### PR TITLE
Fix empty / wrong audio output on ALSA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "http://docs.rs/rodio"
 
 [dependencies]
 claxon = { version = "0.3.0", optional = true }
-cpal = "0.5.1"
+cpal = "0.6.0"
 hound = { version = "1.0.0", optional = true }
 lazy_static = "0.1.12"
 lewton = { version = "0.5", optional = true }


### PR DESCRIPTION
I am not sure if this fix can be merged without careful review.

- The update from `cpal 0.5.1` to `cpal 0.6.0` fixes #135 - you at least get **some** sound on Linux now. I don't know the reason for this or what happened between `0.5.1` and `0.6.0`.
- The code change now does this: On the initialization of a new voice, it sets the formats `samples_rate` to the songs samples_rate. If you don't do this, you get stuttering (i.e. between every sample, there is an audible pause, the song is slowed down * 2).

Now I don't quite know as much about audio processing as I'd like to know, but I think what's happening is that the `.with_max_samples_rate()` function sets a samples rate that is incompatible with the actual song being played (resulting in audible tearing). It might be that this should be fixed at a different point in the code, but I'm not completely sure, I haven't digged through the architecture of `rodio` too much.

I originally notice this here: https://github.com/fschutt/LudumDare40/blob/master/src/audio.rs#L74 - the song would only play correctly if I set the samples rate again.

Now an obvious case would be that the song has a weird samples rate that isn't supported by the system, however I am not sure if it is `rodio`-s job to fix this. Of course you could also go ahead and first filter the supported audio formats by the sources sample_rate. But I am not sure if I should do this.

With this PR, the sound on Linux (at least on ALSA) works perfectly for me, but I am not sure if this bug is present on other operating systems.