### PR TITLE
Update cpal dependency to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "http://docs.rs/rodio"
 
 [dependencies]
 claxon = { version = "0.3.0", optional = true }
-cpal = "0.7.0"
+cpal = "0.8"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
 lewton = { version = "0.5", optional = true }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,24 +5,24 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::default_output_device().unwrap();
+    let device = rodio::default_output_device().unwrap();
 
     let file = std::fs::File::open("examples/beep.wav").unwrap();
-    let mut beep1 = rodio::play_once(&endpoint, BufReader::new(file)).unwrap();
+    let mut beep1 = rodio::play_once(&device, BufReader::new(file)).unwrap();
     beep1.set_volume(0.2);
     println!("Started beep1");
 
     thread::sleep(Duration::from_millis(1500));
 
     let file = std::fs::File::open("examples/beep2.wav").unwrap();
-    rodio::play_once(&endpoint, BufReader::new(file))
+    rodio::play_once(&device, BufReader::new(file))
         .unwrap()
         .detach();
     println!("Started beep2");
 
     thread::sleep(Duration::from_millis(1500));
     let file = std::fs::File::open("examples/beep3.ogg").unwrap();
-    let beep3 = rodio::play_once(&endpoint, file).unwrap();
+    let beep3 = rodio::play_once(&device, file).unwrap();
     println!("Started beep3");
 
     thread::sleep(Duration::from_millis(1500));

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::default_endpoint().unwrap();
+    let endpoint = rodio::default_output_device().unwrap();
 
     let file = std::fs::File::open("examples/beep.wav").unwrap();
     let mut beep1 = rodio::play_once(&endpoint, BufReader::new(file)).unwrap();

--- a/examples/music_flac.rs
+++ b/examples/music_flac.rs
@@ -3,8 +3,8 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::default_output_device().unwrap();
-    let sink = rodio::Sink::new(&endpoint);
+    let device = rodio::default_output_device().unwrap();
+    let sink = rodio::Sink::new(&device);
 
     let file = std::fs::File::open("examples/music.flac").unwrap();
     sink.append(rodio::Decoder::new(BufReader::new(file)).unwrap());

--- a/examples/music_flac.rs
+++ b/examples/music_flac.rs
@@ -3,7 +3,7 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::default_endpoint().unwrap();
+    let endpoint = rodio::default_output_device().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.flac").unwrap();

--- a/examples/music_ogg.rs
+++ b/examples/music_ogg.rs
@@ -3,8 +3,8 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::default_output_device().unwrap();
-    let sink = rodio::Sink::new(&endpoint);
+    let device = rodio::default_output_device().unwrap();
+    let sink = rodio::Sink::new(&device);
 
     let file = std::fs::File::open("examples/music.ogg").unwrap();
     sink.append(rodio::Decoder::new(BufReader::new(file)).unwrap());

--- a/examples/music_ogg.rs
+++ b/examples/music_ogg.rs
@@ -3,7 +3,7 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::default_endpoint().unwrap();
+    let endpoint = rodio::default_output_device().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.ogg").unwrap();

--- a/examples/music_wav.rs
+++ b/examples/music_wav.rs
@@ -3,7 +3,7 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::default_endpoint().unwrap();
+    let endpoint = rodio::default_output_device().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.wav").unwrap();

--- a/examples/music_wav.rs
+++ b/examples/music_wav.rs
@@ -3,8 +3,8 @@ extern crate rodio;
 use std::io::BufReader;
 
 fn main() {
-    let endpoint = rodio::default_output_device().unwrap();
-    let sink = rodio::Sink::new(&endpoint);
+    let device = rodio::default_output_device().unwrap();
+    let sink = rodio::Sink::new(&device);
 
     let file = std::fs::File::open("examples/music.wav").unwrap();
     sink.append(rodio::Decoder::new(BufReader::new(file)).unwrap());

--- a/examples/reverb.rs
+++ b/examples/reverb.rs
@@ -5,7 +5,7 @@ use std::io::BufReader;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::default_endpoint().unwrap();
+    let endpoint = rodio::default_output_device().unwrap();
     let sink = rodio::Sink::new(&endpoint);
 
     let file = std::fs::File::open("examples/music.ogg").unwrap();

--- a/examples/reverb.rs
+++ b/examples/reverb.rs
@@ -5,8 +5,8 @@ use std::io::BufReader;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::default_output_device().unwrap();
-    let sink = rodio::Sink::new(&endpoint);
+    let device = rodio::default_output_device().unwrap();
+    let sink = rodio::Sink::new(&device);
 
     let file = std::fs::File::open("examples/music.ogg").unwrap();
     let source = rodio::Decoder::new(BufReader::new(file)).unwrap();

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::default_endpoint().unwrap();
+    let endpoint = rodio::default_output_device().unwrap();
     let mut sink = rodio::SpatialSink::new(&endpoint,
                                            [-10.0, 0.0, 0.0],
                                            [1.0, 0.0, 0.0],

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -5,8 +5,8 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let endpoint = rodio::default_output_device().unwrap();
-    let mut sink = rodio::SpatialSink::new(&endpoint,
+    let device = rodio::default_output_device().unwrap();
+    let mut sink = rodio::SpatialSink::new(&device,
                                            [-10.0, 0.0, 0.0],
                                            [1.0, 0.0, 0.0],
                                            [-1.0, 0.0, 0.0]);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -15,7 +15,7 @@ use cpal::StreamData;
 use dynamic_mixer;
 use source::Source;
 
-/// Plays a source to an end point until it ends.
+/// Plays a source with a device until it ends.
 ///
 /// The playing uses a background thread.
 pub fn play_raw<S>(device: &Device, source: S)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -121,7 +121,7 @@ fn start<S>(engine: &Arc<Engine>, endpoint: &Device, source: S)
     };
 
     if let Some(stream) = stream_to_start {
-        engine.events_loop.play(stream);
+        engine.events_loop.play_stream(stream);
     }
 
     mixer.add(source);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -105,7 +105,7 @@ fn start<S>(engine: &Arc<Engine>, device: &Device, source: S)
 
         match end_points.entry(device.name()) {
             Entry::Vacant(e) => {
-                let (mixer, stream) = new_stream(engine, device);
+                let (mixer, stream) = new_output_stream(engine, device);
                 e.insert(Arc::downgrade(&mixer));
                 stream_to_start = Some(stream);
                 mixer
@@ -114,7 +114,7 @@ fn start<S>(engine: &Arc<Engine>, device: &Device, source: S)
                 if let Some(m) = e.get().upgrade() {
                     m.clone()
                 } else {
-                    let (mixer, stream) = new_stream(engine, device);
+                    let (mixer, stream) = new_output_stream(engine, device);
                     e.insert(Arc::downgrade(&mixer));
                     stream_to_start = Some(stream);
                     mixer
@@ -132,10 +132,10 @@ fn start<S>(engine: &Arc<Engine>, device: &Device, source: S)
 
 // Adds a new stream to the engine.
 // TODO: handle possible errors here
-fn new_stream(engine: &Arc<Engine>, device: &Device) -> (Arc<dynamic_mixer::DynamicMixerController<f32>>, StreamId) {
+fn new_output_stream(engine: &Arc<Engine>, device: &Device) -> (Arc<dynamic_mixer::DynamicMixerController<f32>>, StreamId) {
     // Determine the format to use for the new stream.
     let format = device
-        .supported_formats()
+        .supported_output_formats()
         .unwrap()
         .fold(None, |f1, f2| {
             if f1.is_none() {
@@ -164,7 +164,7 @@ fn new_stream(engine: &Arc<Engine>, device: &Device) -> (Arc<dynamic_mixer::Dyna
         .expect("The device doesn't support any format!?")
         .with_max_sample_rate();
 
-    let stream_id = engine.events_loop.build_stream(device, &format).unwrap();
+    let stream_id = engine.events_loop.build_output_stream(device, &format).unwrap();
     let (mixer_tx, mixer_rx) = {
         dynamic_mixer::mixer::<f32>(format.channels, format.sample_rate.0)
     };

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use cpal;
 use cpal::Endpoint;
 use cpal::EventLoop;
 use cpal::Sample as CpalSample;
-use cpal::UnknownTypeBuffer;
+use cpal::UnknownTypeOutputBuffer;
 use cpal::VoiceId;
 use dynamic_mixer;
 use source::Source;
@@ -63,7 +63,7 @@ struct Engine {
     end_points: Mutex<HashMap<String, Weak<dynamic_mixer::DynamicMixerController<f32>>>>,
 }
 
-fn audio_callback(engine: &Arc<Engine>, voice_id: VoiceId, mut buffer: UnknownTypeBuffer) {
+fn audio_callback(engine: &Arc<Engine>, voice_id: VoiceId, mut buffer: UnknownTypeOutputBuffer) {
     let mut dynamic_mixers = engine.dynamic_mixers.lock().unwrap();
 
     let mixer_rx = match dynamic_mixers.get_mut(&voice_id) {
@@ -72,17 +72,17 @@ fn audio_callback(engine: &Arc<Engine>, voice_id: VoiceId, mut buffer: UnknownTy
     };
 
     match buffer {
-        UnknownTypeBuffer::U16(ref mut buffer) => {
+        UnknownTypeOutputBuffer::U16(ref mut buffer) => {
             for d in buffer.iter_mut() {
                 *d = mixer_rx.next().map(|s| s.to_u16()).unwrap_or(0u16);
             }
         },
-        UnknownTypeBuffer::I16(ref mut buffer) => {
+        UnknownTypeOutputBuffer::I16(ref mut buffer) => {
             for d in buffer.iter_mut() {
                 *d = mixer_rx.next().map(|s| s.to_i16()).unwrap_or(0i16);
             }
         },
-        UnknownTypeBuffer::F32(ref mut buffer) => {
+        UnknownTypeOutputBuffer::F32(ref mut buffer) => {
             for d in buffer.iter_mut() {
                 *d = mixer_rx.next().unwrap_or(0f32);
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -64,7 +64,7 @@ struct Engine {
     end_points: Mutex<HashMap<String, Weak<dynamic_mixer::DynamicMixerController<f32>>>>,
 }
 
-fn audio_callback(engine: &Arc<Engine>, stream_id: StreamId, mut buffer: StreamData) {
+fn audio_callback(engine: &Arc<Engine>, stream_id: StreamId, buffer: StreamData) {
     let mut dynamic_mixers = engine.dynamic_mixers.lock().unwrap();
 
     let mixer_rx = match dynamic_mixers.get_mut(&stream_id) {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10,7 +10,7 @@ use cpal::Device;
 use cpal::EventLoop;
 use cpal::Sample as CpalSample;
 use cpal::UnknownTypeOutputBuffer;
-use cpal::VoiceId;
+use cpal::StreamId;
 use dynamic_mixer;
 use source::Source;
 
@@ -57,13 +57,13 @@ struct Engine {
     // The events loop which the voices are created with.
     events_loop: EventLoop,
 
-    dynamic_mixers: Mutex<HashMap<VoiceId, dynamic_mixer::DynamicMixer<f32>>>,
+    dynamic_mixers: Mutex<HashMap<StreamId, dynamic_mixer::DynamicMixer<f32>>>,
 
     // TODO: don't use the endpoint name, as it's slow
     end_points: Mutex<HashMap<String, Weak<dynamic_mixer::DynamicMixerController<f32>>>>,
 }
 
-fn audio_callback(engine: &Arc<Engine>, voice_id: VoiceId, mut buffer: UnknownTypeOutputBuffer) {
+fn audio_callback(engine: &Arc<Engine>, voice_id: StreamId, mut buffer: UnknownTypeOutputBuffer) {
     let mut dynamic_mixers = engine.dynamic_mixers.lock().unwrap();
 
     let mixer_rx = match dynamic_mixers.get_mut(&voice_id) {
@@ -128,7 +128,7 @@ fn start<S>(engine: &Arc<Engine>, endpoint: &Device, source: S)
 
 // Adds a new voice to the engine.
 // TODO: handle possible errors here
-fn new_voice(engine: &Arc<Engine>, endpoint: &Device) -> (Arc<dynamic_mixer::DynamicMixerController<f32>>, VoiceId) {
+fn new_voice(engine: &Arc<Engine>, endpoint: &Device) -> (Arc<dynamic_mixer::DynamicMixerController<f32>>, StreamId) {
     // Determine the format to use for the new voice.
     let format = endpoint
         .supported_formats()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -88,6 +88,9 @@ fn audio_callback(engine: &Arc<Engine>, stream_id: StreamId, mut buffer: StreamD
                 *d = mixer_rx.next().unwrap_or(0f32);
             }
         },
+        StreamData::Input { buffer: _ } => {
+            panic!("Can't play an input stream!");
+        }
     };
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -75,7 +75,7 @@ fn audio_callback(engine: &Arc<Engine>, stream_id: StreamId, buffer: StreamData)
     match buffer {
         StreamData::Output { buffer: UnknownTypeOutputBuffer::U16(mut buffer) } => {
             for d in buffer.iter_mut() {
-                *d = mixer_rx.next().map(|s| s.to_u16()).unwrap_or(0u16);
+                *d = mixer_rx.next().map(|s| s.to_u16()).unwrap_or(u16::max_value() / 2);
             }
         },
         StreamData::Output { buffer: UnknownTypeOutputBuffer::I16(mut buffer) } => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,7 @@ use std::sync::Weak;
 use std::thread::Builder;
 
 use cpal;
-use cpal::Endpoint;
+use cpal::Device;
 use cpal::EventLoop;
 use cpal::Sample as CpalSample;
 use cpal::UnknownTypeOutputBuffer;
@@ -17,7 +17,7 @@ use source::Source;
 /// Plays a source to an end point until it ends.
 ///
 /// The playing uses a background thread.
-pub fn play_raw<S>(endpoint: &Endpoint, source: S)
+pub fn play_raw<S>(endpoint: &Device, source: S)
     where S: Source<Item = f32> + Send + 'static
 {
     lazy_static! {
@@ -91,7 +91,7 @@ fn audio_callback(engine: &Arc<Engine>, voice_id: VoiceId, mut buffer: UnknownTy
 }
 
 // Builds a new sink that targets a given endpoint.
-fn start<S>(engine: &Arc<Engine>, endpoint: &Endpoint, source: S)
+fn start<S>(engine: &Arc<Engine>, endpoint: &Device, source: S)
     where S: Source<Item = f32> + Send + 'static
 {
     let mut voice_to_start = None;
@@ -128,7 +128,7 @@ fn start<S>(engine: &Arc<Engine>, endpoint: &Endpoint, source: S)
 
 // Adds a new voice to the engine.
 // TODO: handle possible errors here
-fn new_voice(engine: &Arc<Engine>, endpoint: &Endpoint) -> (Arc<dynamic_mixer::DynamicMixerController<f32>>, VoiceId) {
+fn new_voice(engine: &Arc<Engine>, endpoint: &Device) -> (Arc<dynamic_mixer::DynamicMixerController<f32>>, VoiceId) {
     // Determine the format to use for the new voice.
     let format = endpoint
         .supported_formats()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -151,7 +151,7 @@ fn new_stream(engine: &Arc<Engine>, endpoint: &Device) -> (Arc<dynamic_mixer::Dy
                 return Some(f2);
             }
 
-            // Priviledge outputs with 2 channels for now.
+            // Privilege outputs with 2 channels for now.
             if f2.channels == 2 && f1.channels != 2 {
                 return Some(f2);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ extern crate lazy_static;
 extern crate lewton;
 extern crate cgmath;
 
-pub use cpal::{Endpoint, default_endpoint, endpoints, get_default_endpoint, get_endpoints_list};
+pub use cpal::{Device, default_endpoint, endpoints, get_default_endpoint, get_endpoints_list};
 
 pub use conversions::Sample;
 pub use decoder::Decoder;
@@ -118,7 +118,7 @@ pub mod source;
 
 /// Plays a sound once. Returns a `Sink` that can be used to control the sound.
 #[inline]
-pub fn play_once<R>(endpoint: &Endpoint, input: R) -> Result<Sink, decoder::DecoderError>
+pub fn play_once<R>(endpoint: &Device, input: R) -> Result<Sink, decoder::DecoderError>
     where R: Read + Seek + Send + 'static
 {
     let input = decoder::Decoder::new(input)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,11 @@
 //! use std::io::BufReader;
 //! use rodio::Source;
 //!
-//! let endpoint = rodio::default_output_device().unwrap();
+//! let device = rodio::default_output_device().unwrap();
 //!
 //! let file = File::open("sound.ogg").unwrap();
 //! let source = rodio::Decoder::new(BufReader::new(file)).unwrap();
-//! rodio::play_raw(&endpoint, source.convert_samples());
+//! rodio::play_raw(&device, source.convert_samples());
 //! ```
 //!
 //! ## Sink
@@ -38,8 +38,8 @@
 //! ```no_run
 //! use rodio::Sink;
 //!
-//! let endpoint = rodio::default_output_device().unwrap();
-//! let sink = Sink::new(&endpoint);
+//! let device = rodio::default_output_device().unwrap();
+//! let sink = Sink::new(&device);
 //!
 //! // Add a dummy source of the sake of the example.
 //! let source = rodio::source::SineWave::new(440);
@@ -72,7 +72,7 @@
 //! ## How it works under the hood
 //!
 //! Rodio spawns a background thread that is dedicated to reading from the sources and sending
-//! the output to the endpoint. Whenever you give up ownership of a `Source` in order to play it,
+//! the output to the device. Whenever you give up ownership of a `Source` in order to play it,
 //! it is sent to this background thread where it will be read by rodio.
 //!
 //! All the sounds are mixed together by rodio before being sent to the operating system or the
@@ -118,11 +118,11 @@ pub mod source;
 
 /// Plays a sound once. Returns a `Sink` that can be used to control the sound.
 #[inline]
-pub fn play_once<R>(endpoint: &Device, input: R) -> Result<Sink, decoder::DecoderError>
+pub fn play_once<R>(device: &Device, input: R) -> Result<Sink, decoder::DecoderError>
     where R: Read + Seek + Send + 'static
 {
     let input = decoder::Decoder::new(input)?;
-    let sink = Sink::new(endpoint);
+    let sink = Sink::new(device);
     sink.append(input);
     Ok(sink)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! - Create an object that represents the streaming sound. It can be a sine wave, a buffer, a
 //!   [decoder](decoder/index.html), etc. or even your own type that implements
 //!   [the `Source` trait](source/trait.Source.html).
-//! - Choose an output with the [`endpoints`](fn.endpoints.html) or
+//! - Choose an output with the [`devices`](fn.devices.html) or
 //!   [`default_output_device`](fn.default_output_device.html) functions.
 //! - Call [`play_raw(output, source)`](fn.play_raw.html).
 //!
@@ -94,7 +94,7 @@ extern crate lazy_static;
 extern crate lewton;
 extern crate cgmath;
 
-pub use cpal::{Device, default_output_device, default_input_device, endpoints, get_default_endpoint, get_endpoints_list};
+pub use cpal::{Device, default_output_device, default_input_device, devices, output_devices, input_devices};
 
 pub use conversions::Sample;
 pub use decoder::Decoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!   [decoder](decoder/index.html), etc. or even your own type that implements
 //!   [the `Source` trait](source/trait.Source.html).
 //! - Choose an output with the [`endpoints`](fn.endpoints.html) or
-//!   [`default_endpoint`](fn.default_endpoint.html) functions.
+//!   [`default_output_device`](fn.default_output_device.html) functions.
 //! - Call [`play_raw(output, source)`](fn.play_raw.html).
 //!
 //! The `play_raw` function expects the source to produce `f32`s, which may not be the case. If you
@@ -20,7 +20,7 @@
 //! use std::io::BufReader;
 //! use rodio::Source;
 //!
-//! let endpoint = rodio::default_endpoint().unwrap();
+//! let endpoint = rodio::default_output_device().unwrap();
 //!
 //! let file = File::open("sound.ogg").unwrap();
 //! let source = rodio::Decoder::new(BufReader::new(file)).unwrap();
@@ -38,7 +38,7 @@
 //! ```no_run
 //! use rodio::Sink;
 //!
-//! let endpoint = rodio::default_endpoint().unwrap();
+//! let endpoint = rodio::default_output_device().unwrap();
 //! let sink = Sink::new(&endpoint);
 //!
 //! // Add a dummy source of the sake of the example.
@@ -94,7 +94,7 @@ extern crate lazy_static;
 extern crate lewton;
 extern crate cgmath;
 
-pub use cpal::{Device, default_endpoint, endpoints, get_default_endpoint, get_endpoints_list};
+pub use cpal::{Device, default_output_device, default_input_device, endpoints, get_default_endpoint, get_endpoints_list};
 
 pub use conversions::Sample;
 pub use decoder::Decoder;

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
 use std::time::Duration;
 
-use Endpoint;
+use Device;
 use Sample;
 use Source;
 use source::Done;
@@ -36,7 +36,7 @@ struct Controls {
 impl Sink {
     /// Builds a new `Sink`.
     #[inline]
-    pub fn new(endpoint: &Endpoint) -> Sink {
+    pub fn new(endpoint: &Device) -> Sink {
         let (queue_tx, queue_rx) = queue::queue(true);
         play_raw(endpoint, queue_rx);
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -13,7 +13,7 @@ use source::Done;
 use play_raw;
 use queue;
 
-/// Handle to an endpoint that outputs sounds.
+/// Handle to an device that outputs sounds.
 ///
 /// Dropping the `Sink` stops all sounds. You can use `detach` if you want the sounds to continue
 /// playing.
@@ -36,9 +36,9 @@ struct Controls {
 impl Sink {
     /// Builds a new `Sink`.
     #[inline]
-    pub fn new(endpoint: &Device) -> Sink {
+    pub fn new(device: &Device) -> Sink {
         let (queue_tx, queue_rx) = queue::queue(true);
-        play_raw(endpoint, queue_rx);
+        play_raw(device, queue_rx);
 
         Sink {
             queue_tx: queue_tx,

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -23,11 +23,11 @@ struct SoundPositions {
 impl SpatialSink {
     /// Builds a new `SpatialSink`.
     #[inline]
-    pub fn new(endpoint: &Device, emitter_position: [f32; 3], left_ear: [f32; 3],
+    pub fn new(device: &Device, emitter_position: [f32; 3], left_ear: [f32; 3],
                right_ear: [f32; 3])
                -> SpatialSink {
         SpatialSink {
-            sink: Sink::new(endpoint),
+            sink: Sink::new(device),
             positions: Arc::new(Mutex::new(SoundPositions {
                                                emitter_position,
                                                left_ear,

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -1,5 +1,5 @@
 
-use Endpoint;
+use Device;
 use Sample;
 use Sink;
 use Source;
@@ -23,7 +23,7 @@ struct SoundPositions {
 impl SpatialSink {
     /// Builds a new `SpatialSink`.
     #[inline]
-    pub fn new(endpoint: &Endpoint, emitter_position: [f32; 3], left_ear: [f32; 3],
+    pub fn new(endpoint: &Device, emitter_position: [f32; 3], left_ear: [f32; 3],
                right_ear: [f32; 3])
                -> SpatialSink {
         SpatialSink {


### PR DESCRIPTION
Fixes #160.

This pull request includes:
- a bit of refactoring, in order to follow some changes in the naming conventions used in `cpal` 0.8. I also tried to adopt the rodio internals the new naming convention as closely as possible. Let me know if this is desirable or not.
- `cpal` 0.8 introduces a hard distinction between input and output devices, where only the latter is now used in `rodio`.
- [removal](https://github.com/frazar/rodio/commit/255db6aa7195c55df60c487fd8bedebede7433b3) of a `rodio` piece of code choosing the best `Format` for a given `Device` in favour of the `default_output_format()` method provided by `cpal`

There are a number of __breaking changes__ in the user-facing API of `rodio`, in particular
- renamed `Endpoint` to `Device`
- splitted `default_endpoint()` into `default_output_device()` and `default_input_device()`
- renamed `endpoints()` to `devices()`
- introduced `output_devices()` and `input_devices()`

I tried to test the changes by compiling the crates that depdend on `rodio >= 0.6`, [as listed on crates.io](https://crates.io/crates/rodio/reverse_dependencies). In order for these crates to run, I had to adapt to the breaking changes introduced by this pull requests.
They are, 
- [`ggez`](https://crates.io/crates/ggez): compiles fine, tests pass, and examples finally run without being affected by #160 (as opposed to before).
- [`impose`](https://crates.io/crates/impose): compiles, but has no tests
- [`audact`](https://crates.io/crates/audact): compiles, tests pass
- [`macromusic`](https://crates.io/crates/macromusic): compiles, tests dont pass neither before or after my changes.
