### PR TITLE
fix dynamic mixer doc

### DIFF
--- a/src/dynamic_mixer.rs
+++ b/src/dynamic_mixer.rs
@@ -1,4 +1,4 @@
-//! Queue that plays sounds one after the other.
+//! Mixer that plays multiple sounds at the same time.
 
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;


### PR DESCRIPTION
also the vec to_drop creating in the next method could be cached instead of allocated each time ? but it's probably optimised so I don't know just saying...