### PR TITLE
Bumped minimp3 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
 lewton = { version = "0.5", optional = true }
 cgmath = "0.14"
-minimp3 = { version = "0.2.0", optional = true }
+minimp3 = { version = "0.3.0", optional = true }
 
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]


### PR DESCRIPTION
Hi, this PR bumps minimp3 crate version. A new version can be compiled without `clang` installed on the target machine.