### PR TITLE
Update lewton to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ claxon = { version = "0.3.0", optional = true }
 cpal = "0.8"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
-lewton = { version = "0.5", optional = true }
+lewton = { version = "0.8", optional = true }
 cgmath = "0.14"
 minimp3 = { version = "0.3.0", optional = true }
 


### PR DESCRIPTION
See the [changelog](https://github.com/RustAudio/lewton/blob/bbd45f0e7b5a8be95d7b3ee4374d7833444dfef0/CHANGELOG.md) for changes in lewton.

The update increases the minimum required Rust version of lewton to 1.20.0 (from something like 1.9.0 or something even older than that, not entirely sure). I say this update is okay as a) after deleting `Cargo.lock`, I wasn't able to compile this crate with Rust 1.20, so presumably one of rodio's (transitive?) dependencies already requires a newer Rust version and b) 1.20 was released in August 2017 so is almost one year old by now.