### PR TITLE
Update lewton to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ claxon = { version = "0.3.0", optional = true }
 cpal = "0.8"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
-lewton = { version = "0.8", optional = true }
+lewton = { version = "0.9", optional = true }
 cgmath = "0.14"
 minimp3 = { version = "0.3.0", optional = true }
 


### PR DESCRIPTION
See the [changelog](https://github.com/RustAudio/lewton/blob/fa554eabc8ff723779362caed01f723d4efd6097/CHANGELOG.md#release-090---august-16-2018) for changes in lewton.

No change in the MSRV of lewton. It continues to require 1.20.0.