### PR TITLE
added `.stop()` to SpacialSink

### DIFF
--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -113,6 +113,12 @@ impl SpatialSink {
         self.sink.is_paused()
     }
 
+    /// Stops the sink by emptying the queue.
+    #[inline]
+    pub fn stop(&self) {
+        self.sink.stop()
+    }
+
     /// Destroys the sink without stopping the sounds that are still playing.
     #[inline]
     pub fn detach(self) {


### PR DESCRIPTION
As pointed out in this issue [https://github.com/tomaka/rodio/issues/184](184), `SpatialSink` is missing the `stop()` method `Sink` has. Ad-Hoc, I couldn't think of a reason to let this out on purpose, so here is my proposed fix :)

PS: Are there any contributing guidelines for new contributors?
I'm looking for an open source project to contribute to and I really like `rodio`s design and would be very happy if i could help