### PR TITLE
Remove exclusive borrow requirement in Sink, SpatialSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Remove exclusive `&mut` borrow requirements in `Sink` & `SpatialSink` setters.
+
 # Version 0.8.1 (2018-09-18)
 
 - Update `lewton` dependency to 0.9

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -8,7 +8,7 @@ fn main() {
     let device = rodio::default_output_device().unwrap();
 
     let file = std::fs::File::open("examples/beep.wav").unwrap();
-    let mut beep1 = rodio::play_once(&device, BufReader::new(file)).unwrap();
+    let beep1 = rodio::play_once(&device, BufReader::new(file)).unwrap();
     beep1.set_volume(0.2);
     println!("Started beep1");
 

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 fn main() {
     let device = rodio::default_output_device().unwrap();
-    let mut sink = rodio::SpatialSink::new(
+    let sink = rodio::SpatialSink::new(
         &device,
         [-10.0, 0.0, 0.0],
         [1.0, 0.0, 0.0],

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -96,7 +96,7 @@ impl Sink {
     /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than `1.0` will
     /// multiply each sample by this value.
     #[inline]
-    pub fn set_volume(&mut self, value: f32) {
+    pub fn set_volume(&self, value: f32) {
         *self.controls.volume.lock().unwrap() = value;
     }
 

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -36,17 +36,17 @@ impl SpatialSink {
     }
 
     /// Sets the position of the sound emitter in 3 dimensional space.
-    pub fn set_emitter_position(&mut self, pos: [f32; 3]) {
+    pub fn set_emitter_position(&self, pos: [f32; 3]) {
         self.positions.lock().unwrap().emitter_position = pos;
     }
 
     /// Sets the position of the left ear in 3 dimensional space.
-    pub fn set_left_ear_position(&mut self, pos: [f32; 3]) {
+    pub fn set_left_ear_position(&self, pos: [f32; 3]) {
         self.positions.lock().unwrap().left_ear = pos;
     }
 
     /// Sets the position of the right ear in 3 dimensional space.
-    pub fn set_right_ear_position(&mut self, pos: [f32; 3]) {
+    pub fn set_right_ear_position(&self, pos: [f32; 3]) {
         self.positions.lock().unwrap().right_ear = pos;
     }
 
@@ -85,7 +85,7 @@ impl SpatialSink {
     /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than 1.0 will
     /// multiply each sample by this value.
     #[inline]
-    pub fn set_volume(&mut self, value: f32) {
+    pub fn set_volume(&self, value: f32) {
         self.sink.set_volume(value);
     }
 


### PR DESCRIPTION
I found it a little strange that `Sink::set_volume` required an `&mut` borrow. Since this requirement isn't technical it seems better not to.

This change removes such requirements in setters in `Sink` & `SpatialSink`.

If they exist though, I'd be interested in the reasons this might be wanted.