### PR TITLE
Bump minimp3 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
 lewton = { version = "0.9", optional = true }
 cgmath = "0.14"
-minimp3 = { version = "0.3.0", optional = true }
+minimp3 = { version = "0.3.1", optional = true }
 
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
 lewton = { version = "0.9", optional = true }
 cgmath = "0.14"
-minimp3 = { version = "0.3.1", optional = true }
+minimp3 = { version = "0.3.2", optional = true }
 
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]


### PR DESCRIPTION
- Update `slice-deque` dependency just in case (gnzlbg/slice_deque#57)
- Fix mp3 playback clipping issue #212
- Update minimp3 C library