### PR TITLE
Add `inner` accessors for more sources

### DIFF
--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -49,6 +49,24 @@ where
     pub fn set_volume(&mut self, channel: usize, volume: f32) {
         self.channel_volumes[channel] = volume;
     }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
 }
 
 impl<I> Iterator for ChannelVolume<I>

--- a/src/source/delay.rs
+++ b/src/source/delay.rs
@@ -31,6 +31,30 @@ where
     requested_duration: Duration,
 }
 
+impl<I> Delay<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
 impl<I> Iterator for Delay<I>
 where
     I: Source,

--- a/src/source/done.rs
+++ b/src/source/done.rs
@@ -29,6 +29,24 @@ where
             signal_sent: false,
         }
     }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
 }
 
 impl<I: Source> Iterator for Done<I>

--- a/src/source/fadein.rs
+++ b/src/source/fadein.rs
@@ -30,6 +30,30 @@ where
     total_ns: f32,
 }
 
+impl<I> FadeIn<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
 impl<I> Iterator for FadeIn<I>
 where
     I: Source,

--- a/src/source/periodic.rs
+++ b/src/source/periodic.rs
@@ -38,6 +38,32 @@ pub struct PeriodicAccess<I, F> {
     samples_until_update: u32,
 }
 
+impl<I, F> PeriodicAccess<I, F>
+where
+    I: Source,
+    I::Item: Sample,
+    F: FnMut(&mut I),
+{
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
+
 impl<I, F> Iterator for PeriodicAccess<I, F>
 where
     I: Source,

--- a/src/source/samples_converter.rs
+++ b/src/source/samples_converter.rs
@@ -34,6 +34,24 @@ where
             dest: PhantomData,
         }
     }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.inner
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.inner
+    }
 }
 
 impl<I, D> Iterator for SamplesConverter<I, D>

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -26,6 +26,31 @@ where
     factor: f32,
 }
 
+impl<I> Speed<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
+
 impl<I> Iterator for Speed<I>
 where
     I: Source,

--- a/src/source/take.rs
+++ b/src/source/take.rs
@@ -40,6 +40,24 @@ where
         // \|/ the maximum value of `ns` is one billion, so this can't fail
         Duration::new(0, ns as u32)
     }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
 }
 
 impl<I> Iterator for TakeDuration<I>


### PR DESCRIPTION
One slight quirk I've encountered with Rodio is that it seems like only about half of the built-in `Source` types have methods to access their inner data - this means that if you're trying to dig down through several layers of `Source` adaptors (e.g in a `periodic_access` callback), you sometimes end up having to re-order the types.

I've gone though and added the `inner`, `inner_mut` and `into_inner` methods for all of the adaptors that easily support it - I left out ones that aren't just simple wrappers, as I thought it'd be a bit surprising/dodgy to return an inner type that's an implementation detail of the adaptor.