### PR TITLE
Add a len() method to Sink for some insight into the queue state.

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -148,7 +148,13 @@ impl Sink {
     /// Returns true if this sink has no more sounds to play.
     #[inline]
     pub fn empty(&self) -> bool {
-        self.sound_count.load(Ordering::Relaxed) == 0
+        self.len() == 0
+    }
+
+    /// Returns the number of sounds currently in the queue.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.sound_count.load(Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
This seems like a natural addition to the Sink API.

Actually stems from me struggling to get [librespot integration](https://github.com/librespot-org/librespot/pull/277) working properly. The decoding thread depends on a the audio backend to control it's execution rate.

I tried creating a new source iterator with a sync_channel to the the Librespot Sink but I couldn't get it to work. And it was far more complicated than I would have liked. If this doesn't get accepted I'll take another look at a route like that (a blocking buffer Source which can be written to once it's already playing).