### PR TITLE
Immediately apply a Sink's state to the next Source in it's Queue.

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -33,13 +33,20 @@ struct Controls {
 }
 
 impl Sink {
-    /// Builds a new `Sink`.
+    /// Builds a new `Sink`, beginning playback on a Device.
     #[inline]
     pub fn new(device: &Device) -> Sink {
-        let (queue_tx, queue_rx) = queue::queue(true);
+        let (sink, queue_rx) = Sink::new_idle();
         play_raw(device, queue_rx);
+        sink
+    }
 
-        Sink {
+    /// Builds a new `Sink`.
+    #[inline]
+    pub fn new_idle() -> (Sink, queue::SourcesQueueOutput<f32>) {
+        let (queue_tx, queue_rx) = queue::queue(true);
+
+        let sink = Sink {
             queue_tx: queue_tx,
             sleep_until_end: Mutex::new(None),
             controls: Arc::new(Controls {
@@ -49,7 +56,8 @@ impl Sink {
             }),
             sound_count: Arc::new(AtomicUsize::new(0)),
             detached: false,
-        }
+        };
+        (sink, queue_rx)
     }
 
     /// Appends a sound to the queue of sounds to play.
@@ -165,6 +173,63 @@ impl Drop for Sink {
 
         if !self.detached {
             self.controls.stopped.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use buffer::SamplesBuffer;
+    use source::Source;
+    use sink::Sink;
+
+    #[test]
+    fn test_pause_and_stop() {
+        let (sink, mut queue_rx) = Sink::new_idle();
+
+        // assert_eq!(queue_rx.next(), Some(0.0));
+
+        let v = vec![10i16, -10, 20, -20, 30, -30];
+
+        // Low rate to ensure immediate control.
+        sink.append(SamplesBuffer::new(1, 1, v.clone()));
+        let mut src = SamplesBuffer::new(1, 1, v.clone()).convert_samples();
+
+        assert_eq!(queue_rx.next(), src.next());
+        assert_eq!(queue_rx.next(), src.next());
+
+        sink.pause();
+
+        assert_eq!(queue_rx.next(), Some(0.0));
+
+        sink.play();
+
+        assert_eq!(queue_rx.next(), src.next());
+        assert_eq!(queue_rx.next(), src.next());
+
+        sink.stop();
+
+        assert_eq!(queue_rx.next(), Some(0.0));
+
+        assert_eq!(sink.empty(), true);
+    }
+
+    #[test]
+    fn test_volume() {
+        let (sink, mut queue_rx) = Sink::new_idle();
+
+        let v = vec![10i16, -10, 20, -20, 30, -30];
+
+        // High rate to avoid immediate control.
+        sink.append(SamplesBuffer::new(2, 44100, v.clone()));
+        let src = SamplesBuffer::new(2, 44100, v.clone()).convert_samples();
+
+        let mut src = src.amplify(0.5);
+        sink.set_volume(0.5);
+
+        for _ in 0..v.len() {
+            assert_eq!(queue_rx.next(), src.next());
         }
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -211,7 +211,16 @@ where
         fadein::fadein(self, duration)
     }
 
-    /// Calls the `access` closure on `Self` every time `period` elapsed.
+    /// Calls the `access` closure on `Self` the first time the source is iterated and every
+    /// time `period` elapses.
+    ///
+    /// Later changes in either `sample_rate()` or `channels_count()` won't be reflected in
+    /// the rate of access.
+    ///
+    /// The rate is based on playback speed, so both the following will call `access` when the
+    /// same samples are reached:
+    /// `periodic_access(Duration::from_secs(1), ...).speed(2.0)`
+    /// `speed(2.0).periodic_access(Duration::from_secs(2), ...)`
     #[inline]
     fn periodic_access<F>(self, period: Duration, access: F) -> PeriodicAccess<Self, F>
     where

--- a/src/source/periodic.rs
+++ b/src/source/periodic.rs
@@ -12,13 +12,14 @@ where
     // TODO: handle the fact that the samples rate can change
     // TODO: generally, just wrong
     let update_ms = period.as_secs() as u32 * 1_000 + period.subsec_nanos() / 1_000_000;
-    let update_frequency = (update_ms * source.sample_rate()) / 1000;
+    let sample_rate = source.sample_rate() * source.channels() as u32;
+    let update_frequency = (update_ms * sample_rate) / 1000;
 
     PeriodicAccess {
         input: source,
         modifier: modifier,
         update_frequency: update_frequency,
-        samples_until_update: update_frequency,
+        samples_until_update: 1,
     }
 }
 


### PR DESCRIPTION
**The Problem**
When progressing through Sources in a Sink's queue, it takes roughly 2.5ms (on a stereo stream, 5ms on mono) to query and apply the Sink's atomic state.

**Symptoms**
This means stopping a Sink with lots of Sources queued will result in a fuzz noise as a very short section of each queued Source is played one after the other.
This can also cause an almost imperceptibly small moment of sound when adding a Source to an already-paused Sink.
This can cause a very short (potentially very loud) moment of sound when switching to the next Source in a Sink's Queue when a volume is set. In fact abusing a Sink by queuing lots of very short Sources, whilst the Sink has a volume set, completely garbles the sound.

**My Solution**
~Existing implementations of [throttling functions](https://lodash.com/docs/4.17.11#throttle) sometimes have options to enable leading/trailing edge execution. I chose to create a new function which enables leading-edge execution for the throttle callback, as this seems the simplest and completely backwards compatible solution.~ _I've changed periodic_access to trigger it's first callback the first time the source is iterated._

I've also fixed the calculation of the access interval to take into account a Source's channel count. So that access times on mono and stereo streams are consistent.