### PR TITLE
Use nalgebra for Spatial source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
+
 - Remove exclusive `&mut` borrow requirements in `Sink` & `SpatialSink` setters.
+- Use `nalgebra` instead of `cgmath` for `Spatial` source.
 
 # Version 0.8.1 (2018-09-18)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/tomaka/rodio"
 documentation = "http://docs.rs/rodio"
 
 [dependencies]
-claxon = { version = "0.3.0", optional = true }
+claxon = { version = "0.4.2", optional = true }
 cpal = "0.8"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cpal = "0.8"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
 lewton = { version = "0.9", optional = true }
-cgmath = "0.14"
+nalgebra = "0.18"
 minimp3 = { version = "0.3.2", optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,12 +83,12 @@
 
 #![cfg_attr(test, deny(missing_docs))]
 
-extern crate cgmath;
 #[cfg(feature = "flac")]
 extern crate claxon;
 extern crate cpal;
 #[cfg(feature = "wav")]
 extern crate hound;
+extern crate nalgebra;
 #[macro_use]
 extern crate lazy_static;
 #[cfg(feature = "vorbis")]

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -1,4 +1,4 @@
-use cgmath::{InnerSpace, Point3};
+use nalgebra::Point3;
 use source::ChannelVolume;
 use std::fmt::Debug;
 use std::time::Duration;


### PR DESCRIPTION
Hiya, I've swapped out `cgmath` for `nalgebra 0.18.0` (current latest) in an effort to reduce the number of dependencies that my project compiles.

The benefits of doing this, from a Rust ecosystem point of view, is that [we're converging on `nalgebra`](https://users.rust-lang.org/t/cgmath-looking-for-new-maintainers/20406/2) as the recommended math library (with full support from cgmath's author @brendanzab).

Alternatively we could just bump cgmath's version, but I'd prefer to switch the crate.

I've tested this on Ubuntu 18.10, and the volume fade in/out appears (sound-appears) to be the same when comparing before and after this change.