### PR TITLE
Bumped `claxon` to 0.4.2 to avoid uninitialized memory read.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/tomaka/rodio"
 documentation = "http://docs.rs/rodio"
 
 [dependencies]
-claxon = { version = "0.3.0", optional = true }
+claxon = { version = "0.4.2", optional = true }
 cpal = "0.8"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"


### PR DESCRIPTION
Hiya, I've bumped `claxon` to 0.4.2 to avoid a security issue (https://github.com/ruuda/claxon/issues/10):

```rust
cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 24 security advisories (from /home/gitlab-runner/.cargo/advisory-db)
    Scanning Cargo.lock for vulnerabilities (535 crate dependencies)
error: Vulnerable crates found!

ID:	 RUSTSEC-2018-0004
Crate:	 claxon
Version: 0.3.3
Date:	 2018-08-25
URL:	 https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c
Title:	 Malicious input could cause uninitialized memory to be exposed
Solution: upgrade to: = 0.3.2 OR >= 0.4.1
```