### PR TITLE
Add support for more FLAC files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/tomaka/rodio"
 documentation = "http://docs.rs/rodio"
 
 [dependencies]
-claxon = { version = "0.3.0", optional = true }
+claxon = { version = "0.4.2", optional = true }
 cpal = "0.8"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"


### PR DESCRIPTION
Bump version of claxon in `Cargo.toml` to add support for FLAC files with LPC order > 12 (relevant issue [here](https://github.com/ruuda/claxon/issues/18))